### PR TITLE
Use vim.islist instead of deprecated vim.tbl_islist

### DIFF
--- a/lua/base/init.lua
+++ b/lua/base/init.lua
@@ -75,7 +75,7 @@ function H.setup_config(config)
   vim.validate({
     integrations = {
       validated.integrations,
-      function(t) return t == nil or vim.tbl_islist(t) end,
+      function(t) return t == nil or vim.islist(t) end,
       "expected a list",
     },
   })


### PR DESCRIPTION
To use neovim nightly without deprecation warning this function needs to be replaced